### PR TITLE
Command updates

### DIFF
--- a/Command/MaintenanceCommand.php
+++ b/Command/MaintenanceCommand.php
@@ -2,6 +2,7 @@
 
 namespace Northern\MaintenanceModeBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -9,12 +10,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 
+#[AsCommand(
+    name: 'northern:maintenance',
+    description: 'Toggle maintenance mode',
+)]
 class MaintenanceCommand extends Command
 {
-    protected static $defaultName = 'northern:maintenance';
-
-    protected static $defaultDescription = 'Toggle maintenance mode';
-
     private Filesystem $filesystem;
 
     private string $flagPath;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -7,7 +7,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('northern_maintenance_mode');
 


### PR DESCRIPTION
### Goal
- Update command to remove deprecated overwriting of final class properties.
- Add return type to `getConfigTreeBuilder` to address deprecation warning.