### PR TITLE
Native Return Type Declaration

### DIFF
--- a/Command/MaintenanceCommand.php
+++ b/Command/MaintenanceCommand.php
@@ -31,7 +31,7 @@ class MaintenanceCommand extends Command
         $this->flagPath   = $flagPath;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->addOption('enable', null, InputOption::VALUE_NONE, 'Enable maintenance mode')
              ->addOption('disable', null, InputOption::VALUE_NONE, 'Disable maintenance mode');


### PR DESCRIPTION
Add `void` as explicit return type for `Symfony\Component\Console\Command\Command::configure()` method to address deprecation notice.